### PR TITLE
Rollen ohne Layout von VOCS-Auswahl ausschließen

### DIFF
--- a/src/HTML/app/vocs/views/auth/js/view.js
+++ b/src/HTML/app/vocs/views/auth/js/view.js
@@ -30,6 +30,7 @@
 import * as ov_Auth from "/lib/ov_auth.js";
 import * as ov_Websockets from "/lib/ov_websocket_list.js";
 import * as CSS from "/css/css.js";
+import { has_layout } from "/lib/ov_object_model/ov_role_model.js";
 
 // import custom HTML elements
 import ov_Nav from "/components/nav/nav.js";
@@ -149,19 +150,20 @@ export function set_server_id(server_url, server_name) {
 
 function populate_role_list() {
     let user = ov_Websockets.user();
-    if (user.roles.length === 0) {
+    user.roles.sort();
+
+    let roles = user.roles.values.filter((role) => role.id !== "admin" && has_layout(role));
+
+    if (roles.length === 0) {
         set_message("You have no roles. " +
             "To gain access to roles please contact the project or domain admin.");
     } else {
-        user.roles.sort();
-        for (let role of user.roles.values) {
-            if (role.id !== "admin") {
-                let name = role.name;
-                if (!name)
-                    name = role.id;
-                // DOM.role_list.add_item(role.dom_id, name + " (" + role.project + ")", role.id);
-                DOM.role_list.add_item(role.dom_id, name, role.id);
-            }
+        for (let role of roles) {
+            let name = role.name;
+            if (!name)
+                name = role.id;
+            // DOM.role_list.add_item(role.dom_id, name + " (" + role.project + ")", role.id);
+            DOM.role_list.add_item(role.dom_id, name, role.id);
         }
     }
     activate_stepper(DOM.authorization_step);

--- a/src/HTML/app/vocs/views/loops/js/ui/menu_slider.js
+++ b/src/HTML/app/vocs/views/loops/js/ui/menu_slider.js
@@ -32,6 +32,7 @@ import * as Loop_View from "./loop_view.js";
 import * as ov_Websockets from "/lib/ov_websocket_list.js";
 import * as ov_WebRTCs from "/lib/ov_media/ov_webrtc_list.js";
 import * as ov_Auth from "/lib/ov_auth.js";
+import { has_layout } from "/lib/ov_object_model/ov_role_model.js";
 
 import * as ov_Web_Storage from "/lib/ov_utils/ov_web_storage.js";
 
@@ -134,14 +135,13 @@ export function redraw_user() {
 export async function redraw_roles() {
     DOM.role_select.clear();
     if (ov_Websockets.user()) {
-        for (let role of ov_Websockets.user().roles.values) {
-            if (role.id !== "admin") {
-                let name = role.name;
-                if (!name)
-                    name = role.id;
-                // await DOM.role_select.add_item(role.id, name + "\n (" + role.project + ")", role.id);
-                await DOM.role_select.add_item(role.id, name, role.id);
-            }
+        let roles = ov_Websockets.user().roles.values.filter((role) => role.id !== "admin" && has_layout(role));
+        for (let role of roles) {
+            let name = role.name;
+            if (!name)
+                name = role.id;
+            // await DOM.role_select.add_item(role.id, name + "\n (" + role.project + ")", role.id);
+            await DOM.role_select.add_item(role.id, name, role.id);
         }
         DOM.role_select.value = ov_Websockets.user().role;
     }

--- a/src/HTML/lib/ov_object_model/ov_role_model.js
+++ b/src/HTML/lib/ov_object_model/ov_role_model.js
@@ -30,13 +30,25 @@
 import ov_Parse_Exception from "/lib/ov_exception/ov_parse_exception.js";
 import create_uuid from "/lib/ov_utils/ov_uuid.js";
 
+export function has_layout(role) {
+    if (!role || !role.layout || typeof role.layout !== "object")
+        return false;
+
+    return Object.values(role.layout).some((positions) => {
+        return Array.isArray(positions) && positions.some((position) => {
+            return position && position.page !== undefined && position.page !== null && position.page !== "";
+        });
+    });
+}
+
 export default class ov_Role {
-    constructor(id, name, abbreviation, color, project, domain) {
+    constructor(id, name, abbreviation, color, project, domain, layout) {
         this.id = id;
         this.name = name;
         this.color = color;
         this.project = project;
         this.domain = domain;
+        this.layout = layout;
 
         // dom id has to start with a letter, uuid may start with a number
         this._dom_id = "role_" + create_uuid();
@@ -82,6 +94,14 @@ export default class ov_Role {
         return this._domain;
     }
 
+    set layout(layout) {
+        this._layout = layout;
+    }
+
+    get layout() {
+        return this._layout;
+    }
+
     set users(array) {
         this._users = array;
     }
@@ -105,6 +125,6 @@ export default class ov_Role {
         /*if (!json.hasOwnProperty("color")) // optional
             json.color = "#909090"; // grey*/
 
-        return new this(id, name, json.abbreviation, json.color, json.project, json.domain);
+        return new this(id, name, json.abbreviation, json.color, json.project, json.domain, json.layout);
     }
 }


### PR DESCRIPTION
### NEW
- Verhindern, dass auf der VOCS-Nutzerseite Rollen ohne zugeordnetes Layout zur Auswahl angeboten werden, damit nur tatsächlich nutzbare Rollen sichtbar sind.
- Bestehende Rollen-Daten und -Parsing dürfen nicht gebrochen werden; `layout` bleibt optional und muss kompatibel zu bisherigen Rollen ohne Layout bleiben.

### Description
- `ov_Role.parse` wurde so erweitert, dass optionales `json.layout` erhalten und im Konstruktor/Objekt gespeichert wird (Datei `src/HTML/lib/ov_object_model/ov_role_model.js`).
- Wiederverwendbare Helper-Funktion `has_layout(role)` exportiert, die `true` zurückgibt nur wenn `role.layout` ein Objekt ist und mindestens eine Positionsliste mindestens eine Position mit gültigem `page`-Feld enthält (Datei `src/HTML/lib/ov_object_model/ov_role_model.js`).
- `populate_role_list()` in `src/HTML/app/vocs/views/auth/js/view.js` filtert Rollen vor dem Rendern nach `role.id !== "admin"` und `has_layout(role)` und verwendet bei keiner verbleibenden Rolle die bestehende Nachricht `You have no roles...`.
- `redraw_roles()` in `src/HTML/app/vocs/views/loops/js/ui/menu_slider.js` wendet dieselbe Filterlogik an und führt keine zusätzliche Spezialmeldung ein.
