### PR TITLE
fix: Speaker test non working on Chrome

### DIFF
--- a/src/lib/ov_core/src/ov_webserver.c
+++ b/src/lib/ov_core/src/ov_webserver.c
@@ -163,7 +163,7 @@ static bool answer_range(Webserver *self, int socket, const char *path,
         goto error;
 
     if (to == 0)
-        to = all;
+        to = all - 1;
 
     if (!ov_http_message_set_content_range(response, all, from, to))
         goto error;


### PR DESCRIPTION
When a Range request omitted the end offset, the response's Content-Range upper bound was set to the full content length instead of the last valid byte index, off by one from what HTTP range semantics require.

Was preventing Chrome to play the speaker test sound (was working on Safari/Firefox though)