### PR TITLE
fix: style loop volume slider track for webkit browsers

### DIFF
--- a/src/HTML/components/loops/loop/loop.css
+++ b/src/HTML/components/loops/loop/loop.css
@@ -113,6 +113,13 @@
     outline: none;
 }
 
+#loop_volume #loop_volume_input::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 95%;
+    cursor: pointer;
+    background: var(--black_transparent_78);
+}
+
 #loop_volume #loop_volume_input::-webkit-slider-thumb {
     -webkit-appearance: none;
     width: 1.5em;


### PR DESCRIPTION
The volume slider's runnable track had no explicit styling in webkit-based browsers, leaving it inconsistent with the rest of the loop control's appearance.